### PR TITLE
Adding support for priority and changefreq tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,22 @@ The `<lastmod>` tag in the `sitemap.xml` will reflect by priority:
 2. The modified date of the file as reported by `git log`.
 
 
+## `<priority>` and `<changefreq>` tag
+You can optionally specify a _priority_ and _change frequency_ for each page in your site by adding the following to the Front Matter of each page:
+
+```yml
+sitemap_priority: 0.7
+sitemap_change_frequency: weekly
+```
+
+This will add the following to the `<url>` tag in the `sitemap.xml`:
+
+```xml
+<priority>0.7</priority>
+<changefreq>weekly</changefreq>
+```
+
+
 ## Exclusions
 
 If you would like to exclude specific pages from the sitemap set the

--- a/lib/sitemap.erb
+++ b/lib/sitemap.erb
@@ -13,6 +13,12 @@
       <url>
         <loc><%= xml_escape resource.absolute_url %></loc>
         <lastmod><%= resource.sitemap_last_modified_at.localtime.xmlschema %></lastmod>
+        <% if resource.data.sitemap_priority %>
+        <priority><%= resource.data.sitemap_priority %></priority>
+        <% end %>
+        <% if resource.data.sitemap_change_frequency %>
+        <changefreq><%= resource.data.sitemap_change_frequency %></changefreq>
+        <% end %>
       </url>
     <% end %>
   <% end %>
@@ -23,6 +29,12 @@
     <url>
       <loc><%= xml_escape absolute_url(generated_page.url) %></loc>
       <lastmod><%= (generated_page.data.last_modified_at || site.time).localtime.xmlschema %></lastmod>
+      <% if generated_page.data.sitemap_priority %>
+      <priority><%= generated_page.data.sitemap_priority %></priority>
+      <% end %>
+      <% if generated_page.data.sitemap_change_frequency %>
+      <changefreq><%= generated_page.data.sitemap_change_frequency %></changefreq>
+      <% end %>
     </url>
   <% end %>
 
@@ -31,6 +43,12 @@
     <url>
       <loc><%= xml_escape absolute_url(file.relative_path) %></loc>
       <lastmod><%= file.modified_time.localtime.xmlschema %></lastmod>
+      <% if file.data.sitemap_priority %>
+      <priority><%= file.data.sitemap_priority %></priority>
+      <% end %>
+      <% if file.data.sitemap_change_frequency %>
+      <changefreq><%= file.data.sitemap_change_frequency %></changefreq>
+      <% end %>
     </url>
   <% end %>
 </urlset>

--- a/test/fixtures/src/some-subfolder/test_priority_and_changefreq.html
+++ b/test/fixtures/src/some-subfolder/test_priority_and_changefreq.html
@@ -1,0 +1,5 @@
+---
+sitemap_priority: 0.8
+sitemap_change_frequency: monthly
+---
+This is a page with custom sitemap priority and change frequency.

--- a/test/test_sitemap.rb
+++ b/test/test_sitemap.rb
@@ -116,7 +116,7 @@ class TestSitemap < BridgetownSitemap::Test
     end
 
     it "includes the correct number of items for the sitemap" do
-      assert_equal 18, @sitemap.scan(%r!(?=<url>)!).count
+      assert_equal 19, @sitemap.scan(%r!(?=<url>)!).count
     end
 
     it "includes generated pages in the sitemap" do
@@ -125,6 +125,11 @@ class TestSitemap < BridgetownSitemap::Test
 
     it "renders liquid in the robots.txt" do
       assert_match "Sitemap: https://example.com/sitemap.xml", @robots
+    end
+
+    it "renders the priority and changefreq properties if needed" do
+      assert_match %r!<priority>0.8</priority>!, @sitemap
+      assert_match %r!<changefreq>monthly</changefreq>!, @sitemap
     end
   end
 


### PR DESCRIPTION
This PR adds support for defining the `priority` and `changefreq` tags in the sitemap.xml file. This is done by adding two new variables to the front matter of a page:

```yml
sitemap_priority: 0.7
sitemap_change_frequency: weekly
```

This will add the following to the `<url>` tag in the `sitemap.xml`:

```xml
<priority>0.7</priority>
<changefreq>weekly</changefreq>
```