### PR TITLE
feat: support adding custom urls to sitemap

### DIFF
--- a/lib/bridgetown-sitemap/builder.rb
+++ b/lib/bridgetown-sitemap/builder.rb
@@ -42,7 +42,7 @@ module BridgetownSitemap
       site_map.data.layout = "none"
       site_map.data.static_files = static_files
       site_map.data.xsl = file_exists?("sitemap.xsl")
-      site_map.data.custom_urls = @site.config.dig("sitemap", "custom_urls") || [] # Add this line
+      site_map.data.custom_urls = @site.config.dig("sitemap", "custom_urls") || []
       site_map
     end
 

--- a/lib/bridgetown-sitemap/builder.rb
+++ b/lib/bridgetown-sitemap/builder.rb
@@ -42,6 +42,7 @@ module BridgetownSitemap
       site_map.data.layout = "none"
       site_map.data.static_files = static_files
       site_map.data.xsl = file_exists?("sitemap.xsl")
+      site_map.data.custom_urls = @site.config.dig("sitemap", "custom_urls") || [] # Add this line
       site_map
     end
 

--- a/lib/sitemap.erb
+++ b/lib/sitemap.erb
@@ -82,4 +82,17 @@
       <% end %>
     </url>
   <% end %>
+
+  <% page.data.custom_urls.each do |custom_url| %>
+    <url>
+      <loc><%= xml_escape custom_url["url"] %></loc>
+      <lastmod><%= custom_url["lastmod"] || Time.now.localtime.xmlschema %></lastmod>
+      <% if custom_url["changefreq"] %>
+        <changefreq><%= custom_url["changefreq"] %></changefreq>
+      <% end %>
+      <% if custom_url["priority"] %>
+        <priority><%= custom_url["priority"] %></priority>
+      <% end %>
+    </url>
+  <% end %>
 </urlset>

--- a/test/test_sitemap.rb
+++ b/test/test_sitemap.rb
@@ -237,4 +237,20 @@ class TestSitemap < BridgetownSitemap::Test
       assert_match %r!<loc>https://example.com/new/</loc>!, @sitemap
     end
   end
+
+  describe "rendering the site with custom URLs" do
+    before(:all) do
+      prepare_site
+      @config["sitemap"] = { "custom_urls" => [{ "url" => "https://example.com/custom-url", "priority" => 0.9, "changefreq" => "weekly" }] }
+      process_site
+
+      @sitemap = File.read(dest_dir("sitemap.xml"))
+    end
+
+    it "includes custom URLs in the sitemap" do
+      assert_match %r!<loc>https://example.com/custom-url</loc>!, @sitemap
+      assert_match %r!<priority>0.9</priority>!, @sitemap
+      assert_match %r!<changefreq>weekly</changefreq>!, @sitemap
+    end
+  end
 end


### PR DESCRIPTION
I recently moved my blog from Bridgetown to Hashnode and added support to bridgetown-sitemap in a fork to take into account custom urls for posts/pages that have migrated to Hashnode. 

**Additional Background**
The sitemap generator takes into account existing pages/posts and Render only redirects URLs when content does not exist at that location. This introduces the issue where the content needs to exist for the sitemap generator, but needs to not exist for Render. To resolve this and have Google properly index my site - I added custom support to added urls to the sitemap.

With this change, users can add custom urls like so:

```yml
# bridgetown.config.yml

sitemap:
  custom_urls:
    - url: "https://mysite.com/some-post"
      lastmod: "2024-12-01T00:00:00Z"
      changefreq: "monthly"
      priority: 0.8
```

I thought I'd open up a PR against this if others were interested in having it available upstream.