### PR TITLE
Skip XML stylesheet declaration for any falsy page.data.xsl value

### DIFF
--- a/lib/sitemap.erb
+++ b/lib/sitemap.erb
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<% if !page.data.xsl.nil? %>
+<% if page.data.xsl %>
   <?xml-stylesheet type="text/xsl" href="/sitemap.xsl"?>
 <% end %>
 

--- a/test/test_sitemap.rb
+++ b/test/test_sitemap.rb
@@ -41,6 +41,10 @@ class TestSitemap < BridgetownSitemap::Test
       refute_match %r!\ATHIS IS MY LAYOUT!, @robots
     end
 
+    it "does not include an XML stylesheet declaration" do
+      refute_match %r!xml-stylesheet!, @sitemap
+    end
+
     it "puts all the pages in the sitemap" do
       assert_match %r!<loc>https://example\.com/</loc>!, @sitemap
       assert_match %r!<loc>https://example\.com/some-subfolder/this-is-a-subpage/</loc>!, @sitemap


### PR DESCRIPTION
This change fixes a bug wherein an XML stylesheet processing instruction is included in the sitemap even when it should not be.

The bug was introduced in 611d5735, in which a `page.data.xsl.present?` check was changed to `!page.data.xsl.nil?`. The problem is that, in the default case, in which there is no `sitemap.xsl` file, `page.data.xsl` will be `false` (rather than `nil`) (because `file_exists?("sitemap.xsl")`, which is checked [here](https://github.com/ayushn21/bridgetown-sitemap/blob/v3.0.1/lib/bridgetown-sitemap/builder.rb#L44), returns `false`, not `nil`).

With this change, an XML stylesheet processing instruction will now only be included if `page.data.xsl` is a truthy value. If the value is `false` (as is the default), an XML stylesheet processing instruction will no longer be included.