### PR TITLE
Cache git_repo? check at the class level

### DIFF
--- a/lib/bridgetown-sitemap/git_inspector.rb
+++ b/lib/bridgetown-sitemap/git_inspector.rb
@@ -24,7 +24,13 @@ module BridgetownSitemap
       end
 
       def git_repo?
-        system "git status", out: File::NULL, err: File::NULL
+        self.class.git_repo?
+      end
+
+      def self.git_repo?
+        return @git_repo if defined?(@git_repo)
+
+        @git_repo = system("git rev-parse --is-inside-work-tree", out: File::NULL, err: File::NULL)
       end
 
       def cache

--- a/test/test_sitemap.rb
+++ b/test/test_sitemap.rb
@@ -242,6 +242,20 @@ class TestSitemap < BridgetownSitemap::Test
     end
   end
 
+  describe "GitInspector" do
+    it "caches the git_repo? check at the class level" do
+      BridgetownSitemap::GitInspector.remove_instance_variable(:@git_repo) if
+        BridgetownSitemap::GitInspector.instance_variable_defined?(:@git_repo)
+
+      result = BridgetownSitemap::GitInspector.git_repo?
+
+      assert BridgetownSitemap::GitInspector.instance_variable_defined?(:@git_repo),
+        "Expected git_repo? result to be cached on the class"
+      assert_equal result, BridgetownSitemap::GitInspector.git_repo?,
+        "Expected cached result to be returned on subsequent calls"
+    end
+  end
+
   describe "rendering the site with custom URLs" do
     before(:all) do
       prepare_site


### PR DESCRIPTION
## Summary
- Cache the `git_repo?` result as a class-level instance variable instead of running a shell command per resource
- Use `git rev-parse --is-inside-work-tree` instead of `git status` (cheaper, doesn't scan working tree)

## Problem
A new `GitInspector` is instantiated per resource, and `git_repo?` runs `git status` each time. On a site with ~400 pages, that's ~400 redundant shell calls adding several seconds to build time.

## Test plan
- All existing tests pass
- Verified on a production site (~235 URLs): build overhead dropped from ~5s to ~1.6s