### PR TITLE
Fix resource grouping for pages with the same slug in different paths

### DIFF
--- a/lib/bridgetown-sitemap/grouped_generated_pages.rb
+++ b/lib/bridgetown-sitemap/grouped_generated_pages.rb
@@ -3,8 +3,15 @@
 module BridgetownSitemap
   class GroupedGeneratedPages
     def initialize(generated_pages)
-      @grouped_generated_pages = \
-        generated_pages.group_by { |page| page.data.slug }.values
+      @grouped_generated_pages = generated_pages.group_by do |page|
+        url = if page.respond_to?(:original_resource) && page.original_resource
+          page.original_resource.relative_url.to_s
+        else
+          page.url.to_s
+        end
+        locale = page.data.locale.to_s
+        locale.empty? ? url : url.sub("/#{locale}/", "/")
+      end.values
     end
 
     def each(locale:, &block)

--- a/lib/bridgetown-sitemap/grouped_resources.rb
+++ b/lib/bridgetown-sitemap/grouped_resources.rb
@@ -4,7 +4,10 @@ module BridgetownSitemap
   class GroupedResources
     def initialize(resources)
       @grouped_resources = resources.group_by do |resource|
-         [resource.data.slug, resource.date]
+        url = resource.relative_url.to_s
+        locale = resource.data.locale.to_s
+        base_url = locale.empty? ? url : url.sub("/#{locale}/", "/")
+        [base_url, resource.date]
       end.values
     end
 

--- a/lib/sitemap.erb
+++ b/lib/sitemap.erb
@@ -49,7 +49,7 @@
       <url>
         <loc><%= xml_escape absolute_url(default.url) %></loc>
 
-        <% group.each do |page| %>
+        <% group.reject { |p| p.respond_to?(:original_resource) && p.original_resource && p.url != default.url }.each do |page| %>
           <% if !page.data.locale || site.locale == page.data.locale %>
             <xhtml:link rel="alternate" hreflang="x-default" href="<%= xml_escape absolute_url(page.url) %>" />
           <% end %>

--- a/test/fixtures/config/initializers.rb
+++ b/test/fixtures/config/initializers.rb
@@ -10,6 +10,7 @@ Bridgetown.configure do |config|
 
   available_locales [ :en, :ru ]
   default_locale :en
+  pagination { enabled true }
 
   init :"bridgetown-sitemap"
 end

--- a/test/fixtures/plugins/builders/generated_pages.rb
+++ b/test/fixtures/plugins/builders/generated_pages.rb
@@ -10,8 +10,13 @@ class Builders::GeneratedPages < SiteBuilder
       generated_page_ru.data.layout = "default"
       generated_page_ru.data.locale = :ru
 
+      generated_page_alt = Bridgetown::GeneratedPage.new(site, site.source, "/alt", "generated_page.erb")
+      generated_page_alt.content = "<%= 'alt generated page'.capitalize %>"
+      generated_page_alt.data.layout = "default"
+
       site.generated_pages << generated_page
       site.generated_pages << generated_page_ru
+      site.generated_pages << generated_page_alt
     end
   end
 end

--- a/test/fixtures/src/blog/index.html
+++ b/test/fixtures/src/blog/index.html
@@ -1,0 +1,8 @@
+---
+layout: default
+pagination:
+  collection: posts
+  per_page: 4
+---
+
+<h1>Blog Index</h1>

--- a/test/test_sitemap.rb
+++ b/test/test_sitemap.rb
@@ -120,7 +120,26 @@ class TestSitemap < BridgetownSitemap::Test
     end
 
     it "includes the correct number of items for the sitemap" do
-      assert_equal 20, @sitemap.scan(%r!(?=<url>)!).count
+      assert_equal 22, @sitemap.scan(%r!(?=<url>)!).count
+    end
+
+    it "does not merge pages with the same slug but different paths" do
+      assert_match %r!<loc>https://example\.com/</loc>!, @sitemap
+      assert_match %r!<loc>https://example\.com/blog/</loc>!, @sitemap
+    end
+
+    it "does not merge generated pages with the same name but different paths" do
+      assert_match %r!<loc>https://example\.com/generated_page/</loc>!, @sitemap
+      assert_match %r!<loc>https://example\.com/alt/generated_page/</loc>!, @sitemap
+    end
+
+    it "collapses pagination pages with their original page" do
+      assert_match %r!<loc>https://example\.com/blog/</loc>!, @sitemap
+      refute_match %r!<loc>https://example\.com/blog/page/!, @sitemap
+    end
+
+    it "does not list pagination pages as hreflang alternates" do
+      refute_match %r!hreflang.*blog/page/!, @sitemap
     end
 
     it "includes generated pages in the sitemap" do
@@ -257,4 +276,5 @@ class TestSitemap < BridgetownSitemap::Test
       assert_match %r!<changefreq>weekly</changefreq>!, @sitemap
     end
   end
+
 end


### PR DESCRIPTION
## Summary
Group resources and generated pages by locale-stripped URL instead of just slug, so pages with the same name but different paths get separate sitemap entries. Pagination pages correctly collapse with their original page and are excluded from hreflang alternates.

## Problem
Both `GroupedResources` and `GroupedGeneratedPages` grouped by slug alone. Pages like `src/index.html` (homepage) and `src/blog/index.html` (blog index) both have slug `"index"`, causing them to merge into a single `<url>` entry. Same issue affected generated pages at different paths.

Additionally, pagination pages (page 2, 3, etc.) were listed as hreflang alternates of their original page, incorrectly declaring them as language variants.

## Fix
- **Resources**: Group by `[locale_stripped_relative_url, date]`
- **Generated pages**: Use `original_resource.relative_url` for pagination pages (so they collapse with their source page), fall back to `page.url` for non-pagination pages
- **hreflang alternates**: Exclude pagination copies (pages with `original_resource` set whose URL differs from the default) from the alternate links
- Both strip locale prefixes so i18n variants still group correctly

## Test plan
- Added `test/fixtures/src/blog/index.html` with pagination enabled to reproduce both the resource grouping issue and test pagination collapsing
- Added alt generated page at `/alt/` to test non-pagination generated page separation
- Added test asserting both `/` and `/blog/` appear as separate entries (resource grouping)
- Added test asserting `/generated_page/` and `/alt/generated_page/` appear as separate entries (generated page grouping)
- Added test asserting `/blog/` is present and `/blog/page/*` is not (pagination collapsing)
- Added test asserting pagination pages don't appear in hreflang alternates
- All existing tests pass (including i18n grouping with baseurl)